### PR TITLE
Show device instead of displayname and reading

### DIFF
--- a/scripts/sql/050_fhem_f_v_last_update.sql
+++ b/scripts/sql/050_fhem_f_v_last_update.sql
@@ -3,8 +3,7 @@ SELECT
     last_vals.ID,
     last_vals.TIMESTAMP, 
     last_vals.VALUE, 
-    ddm.DISPLAY_NAME,
-    drm.READING
+    ddm.DEVICE
 FROM (
     -- Retrieve last values from battery table
     SELECT 


### PR DESCRIPTION
The view was incorrect as it just showed pooled (and single) devices. In case one pooled device failed, the remaining active device reported live data. This was masking the inactive device and made it impossible to understand if a device is offline.

I changed the view to show all raw devices instead of pooled devices, making this more understandable. 